### PR TITLE
Поправлена ошибка, при которой не проходили тесты на macos

### DIFF
--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -65,7 +65,6 @@ class QueueTest extends AbstractTestCase
     public function testTransportFactoryRegister(): void
     {
         $this->expectException(RedisException::class);
-        $this->expectExceptionMessageMatches('/Temporary failure in name resolution/');
 
         $this->getBitrixEventMock();
         $this->getBitrixConfigurationMock([


### PR DESCRIPTION
При запуске теста testTransportFactoryRegister на macos текст ошибки исключения выглядит следующим образом: "php_network_getaddresses: getaddrinfo for dummy failed: nodename nor servname provided, or not known".  Да и будто бы излишне проверять еще и текст исключения. 