### PR TITLE
Исправил проблему, при которой "падал" stop-workers

### DIFF
--- a/lib/cache/bitrixcache.php
+++ b/lib/cache/bitrixcache.php
@@ -38,13 +38,12 @@ class BitrixCache implements BitrixCacheInterface
         ) ?? false;
     }
 
-    public function getVars(): array
+    public function getVars(): mixed
     {
-        $vars = $this->cache->getVars();
-        return is_array($vars) ? $vars : [];
+        return $this->cache->getVars();
     }
 
-    public function startDataCache(?int $ttl = null, ?string $uniqueString = null, ?string $initDir = null, array $vars = [], ?string $baseDir = null): bool
+    public function startDataCache(?int $ttl = null, ?string $uniqueString = null, ?string $initDir = null, mixed $vars = null, ?string $baseDir = null): bool
     {
         return $this->cache->startDataCache(
             $ttl ?? false,
@@ -55,7 +54,7 @@ class BitrixCache implements BitrixCacheInterface
         ) ?? false;
     }
 
-    public function endDataCache(?array $vars = null): void
+    public function endDataCache(mixed $vars = null): void
     {
         $this->cache->endDataCache($vars ?? false);
     }

--- a/lib/cache/bitrixcacheinterface.php
+++ b/lib/cache/bitrixcacheinterface.php
@@ -7,8 +7,8 @@ interface BitrixCacheInterface
     public function forceRewriting(bool $value): void;
     public function cleanDir(?string $initDir = null, ?string $baseDir = null): void;
     public function initCache(int $ttl, string $uniqueString, ?string $initDir = null, ?string $baseDir = null): bool;
-    public function getVars(): array;
-    public function startDataCache(?int $ttl = null, ?string $uniqueString = null, ?string $initDir = null, array $vars = [], ?string $baseDir = null): bool;
-    public function endDataCache(?array $vars = null): void;
+    public function getVars(): mixed;
+    public function startDataCache(?int $ttl = null, ?string $uniqueString = null, ?string $initDir = null, mixed $vars = null, ?string $baseDir = null): bool;
+    public function endDataCache(mixed $vars = null): void;
     public function clean(string $uniqueString, ?string $initDir = null, ?string $baseDir = null): void;
 }

--- a/tests/Fixtures/DummyCache.php
+++ b/tests/Fixtures/DummyCache.php
@@ -29,13 +29,13 @@ class DummyCache implements BitrixCacheInterface
         return $this->vars;
     }
 
-    public function startDataCache(?int $ttl = null, ?string $uniqueString = null, ?string $initDir = null, array $vars = [], ?string $baseDir = null): bool
+    public function startDataCache(?int $ttl = null, ?string $uniqueString = null, ?string $initDir = null, mixed $vars = null, ?string $baseDir = null): bool
     {
         $this->vars[$uniqueString] = $vars;
         return true;
     }
 
-    public function endDataCache(?array $vars = null): void
+    public function endDataCache(mixed $vars = null): void
     {
     }
 


### PR DESCRIPTION
Bitrix\Main\Data\Cache ввел меня в заблуждение при написании Bsi\Queue\Cache\BitrixCacheInterface (и его реализации Bsi\Queue\Cache\BitrixCache). Сделал $vars типом mixed, вместо array, так как кеш должен уметь хранить что угодно (ну почти).

Так же поправил метод endDataCache в реализации Bsi\Queue\Cache\BitrixCache. Суть проблемы внутри Bitrix\Main\Data\Cache

```php
public function endDataCache($vars = false)
{
   if (!$this->isStarted)
   {
      return;
   }

   $this->isStarted = false;
   $data = [
      'CONTENT' => $this->hasOutput ? ob_get_contents() : '',
      'VARS' => ($vars !== false ? $vars : $this->vars),  // Ранее в $vars передавался null из-за этого кеш создавался пустой
   ];
   // ....
}
```